### PR TITLE
fix: A non-numeric value encountered

### DIFF
--- a/src/PhilGale92Docx/Nodes/Node.php
+++ b/src/PhilGale92Docx/Nodes/Node.php
@@ -269,7 +269,7 @@ abstract class Node {
      * @return int
      */
     protected function _twipToPt($twip){
-        $px = round($twip / 20);
+        $px = round(intval($twip) / 20);
         return $px;
     }
 


### PR DESCRIPTION
when I try to parsing a docx file, there are a lot for errors that show up "A non-numeric value encountered in"... so I add a function (intval) to fix that problem~